### PR TITLE
Add files via upload

### DIFF
--- a/quaterion/loss/centroid_triplet_loss.py
+++ b/quaterion/loss/centroid_triplet_loss.py
@@ -1,0 +1,59 @@
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from torch import LongTensor, Tensor
+
+from quaterion.distances import Distance
+from quaterion.loss.group_loss import GroupLoss
+from quaterion.utils import get_centroids, get_triplet_mask
+
+class CentroidTripletLoss(GroupLoss):
+    """Implements Centroid Triplet Loss.
+
+    Args:
+        margin: Margin value to push negative centroids apart from positive centroids.
+        distance_metric_name: Name of the distance function, e.g., :class:`~quaterion.distances.Distance`.
+    """
+
+    def __init__(
+        self,
+        margin: Optional[float] = 0.5,
+        distance_metric_name: Optional[Distance] = Distance.COSINE,
+    ):
+        super(CentroidTripletLoss, self).__init__(distance_metric_name=distance_metric_name)
+        self._margin = margin
+
+    def get_config_dict(self):
+        return {"margin": self._margin}
+
+    def forward(
+        self,
+        embeddings: Tensor,
+        groups: LongTensor,
+    ) -> Tensor:
+        """Calculates Centroid Triplet Loss with specified embeddings and labels.
+
+        Args:
+            embeddings: shape: (batch_size, vector_length) - Batch of embeddings.
+            groups: shape: (batch_size,) - Batch of labels associated with `embeddings`
+
+        Returns:
+            torch.Tensor: Scalar loss value.
+        """
+        # Compute centroids for each group in the batch
+        centroids = get_centroids(embeddings, groups)
+
+        # Compute distance matrix between centroids
+        centroid_dists = self.distance_metric.distance_matrix(centroids)
+
+        # Generate triplet mask for centroids (indicating valid triplets)
+        triplet_mask = get_triplet_mask(groups)
+
+        # Apply triplet mask to distance matrix
+        masked_dists = centroid_dists * triplet_mask.float()
+
+        # Compute the triplet loss using centroids and masked distances
+        # ...
+
+        return triplet_loss


### PR DESCRIPTION
# Centroid Triplet Loss

This repository contains an implementation of the Centroid Triplet Loss, a loss function used in deep learning for metric learning tasks such as face recognition and clustering.

## Overview

The Centroid Triplet Loss aims to learn embeddings (vectors) in such a way that distances between centroids belonging to the same group or cluster are minimized while distances between centroids of different groups are maximized.

This loss function extends the concept of Triplet Loss by computing centroids for each group within a batch and formulating the loss based on distances between these centroids.

## Example Usage

from centroid_triplet_loss import CentroidTripletLoss

# Create an instance of CentroidTripletLoss
loss_fn = CentroidTripletLoss(margin=0.5)

# Compute the loss for a batch of embeddings and associated labels
loss = loss_fn(embeddings, labels)
